### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.4",
     "composer/installers": "^1.9",
     "helsingborg-stad/acf-export-manager": "~1.0.0",
     "helsingborg-stad/acf-ux-collapse": "~1.0.0",


### PR DESCRIPTION
Update required PHP version. We do not support the 5.x branch of PHP. Therefore we should not accept composer to use it. Minimum required PHP version is at the moment 7.4. 